### PR TITLE
Replacing [Localhost] with more relevant information

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,7 +250,6 @@
 
 <h3 id="networking">Networking</h3>
 <ul>
-  <li><a href="https://hackaday.com/2009/06/16/ekahau-heatmapper-maps-out-wifi-signals/" target="_blank">Ekahau HeatMapper</a></li>
   <li><a href="https://www.namecheap.com/" target="_blank">NameCheap</a></li>
   <li><a href="http://nirsoft.net/network_tools.html" target="_blank">Network Monitoring Tools</a></li>
   <h5><a href="#toc">#toc</a></h5>


### PR DESCRIPTION
Replacing the AP [Localhost] and Robotics [Localhost] links on the readme.bup page. the AP [Localhost] will be replaced by AP CSP and AP CSA pages, and the Robotics [Localhost] will be replaced with the NRG homepage.