### PR TITLE
Add the APCSP reference sheet to "readme.bup"

### DIFF
--- a/readme.bup
+++ b/readme.bup
@@ -73,6 +73,7 @@
 ### AP
 -   [AP CSA](https://code.org/educate/csa){:target="_blank"}
 -   [AP CSP](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/course){:target="_blank"}
+-   [AP CSP Exam Reference Sheet](https://apcentral.collegeboard.org/media/pdf/ap-computer-science-principles-exam-reference-sheet.pdf){:target="_blank"}
 
 ### Arduino
 -   [oomlout](http://oomlout.com/oom.php/){:target="_blank"}


### PR DESCRIPTION
added APCSP reference sheet to AP resources as it is helpful for a quick find for pseudocode, etc.