### PR TITLE
Remove Knights Who Code Club link from activities

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,6 @@
 
 <h3 id="actvities">NHS ACTIVITIES</h3>
 <ul>
-  <li><a href="https://www.instagram.com/girlswhocodenewport/" target="_blank">Knights Who Code Club @ NHS</a></li>
   <li><a href="https://newporthigh.bsd405.org/student-life/clubs-and-activities" target="_blank">Newport High School Clubs</a></li>
   <li><a href="https://bsd405.org/nhs/knights/athletics/" target="_blank">Newport High School Sports</a></li>
   <h5><a href="#toc">#toc</a></h5>


### PR DESCRIPTION
Removed link to Knights Who Code Club from NHS activities.  Club Instagram feed is no longer active